### PR TITLE
add pin! and pins! macros for easy pin selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifive1"
-version = "0.7.0"
+version = "0.7.1"
 repository = "https://github.com/riscv-rust/hifive1"
 authors = ["David Craven <david@craven.ch>"]
 categories = ["embedded", "hardware-support", "no-std"]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,16 +1,18 @@
 ///
 /// Returns single pin for given gpio object mapped accordingly
 /// 
-/// *mappings*
+/// # Mappings
 /// 
-///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
-///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
-///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
-///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
+///   - `spi_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
+///   - `i2c_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
+///   - `serial_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
-/// *example*
+/// # Example
 /// 
-/// `pin!(gpio.spi_mosi) -> gpio.pin3`
+/// ```
+/// let mosi = pin!(gpio, spi_mosi); // gpio.pin3
+/// ```
 /// 
 #[macro_export]
 macro_rules! pin {
@@ -56,17 +58,20 @@ macro_rules! pin {
 ///
 /// Returns tuple of pins for given gpio object mapped accordingly
 /// 
-/// *mappings*
+/// # Mappings
 /// 
-///     - none -- Returns () for empty pin if needed in tuple
-///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
-///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
-///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
-///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
+///   - `none` — Returns `()` for empty pin if needed in tuple
+///   - `spi_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
+///   - `i2c_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
+///   - `serial_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
-/// *example*
+/// # Example
 /// 
-/// `pins!(gpio, (spi_mosi, spi_miso, spi_sck, spi_ss0)) -> (gpio.pin3, gpio.pin4, gpio.pin5, gpio.pin2)`
+/// ```
+/// let (mosi, miso, sck, cs) = pins!(gpio, (spi_mosi, spi_miso, spi_sck, spi_ss0));
+/// // (gpio.pin3, gpio.pin4, gpio.pin5, gpio.pin2)
+/// ```
 /// 
 #[macro_export]
 macro_rules! pins {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -5,7 +5,7 @@
 /// 
 ///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
 ///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
-///   - `uart0_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `uart0_<x>` — UART pins where <x> is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
 /// # Example
@@ -63,7 +63,7 @@ macro_rules! pin {
 ///   - `none` — Returns `()` for empty pin if needed in tuple
 ///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
 ///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
-///   - `uart0_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `uart0_<x>` — UART pins where <x> is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
 /// # Example

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,0 +1,88 @@
+//! GPIO Pin mapping macros crate
+
+///
+/// Hifive1 PIN mappings (alias -> GPIO.pinX)
+/// 
+#[macro_export]
+macro_rules! pin_name {
+    // empty
+    ($gpio:ident, none) => { () };
+    // spi
+    ($gpio:ident, spi_sck) => { $gpio.pin5 };
+    ($gpio:ident, spi_mosi) => { $gpio.pin3 };
+    ($gpio:ident, spi_miso) => { $gpio.pin4 };
+    ($gpio:ident, spi_ss0) => { $gpio.pin2 };
+    // spi_ss1 is not documented
+    ($gpio:ident, spi_ss2) => { $gpio.pin9 };
+    ($gpio:ident, spi_cs3) => { $gpio.pin10 };
+    // i2c
+    ($gpio:ident, i2c_sda) => { $gpio.pin12 };
+    ($gpio:ident, i2c_scl) => { $gpio.pin13 };
+    // serial
+    ($gpio:ident, serial_tx) => { $gpio.pin17 };
+    ($gpio:ident, serial_rx) => { $gpio.pin16 };
+    // digital/physical
+    ($gpio:ident, dig0) => { $gpio.pin16 };
+    ($gpio:ident, dig1) => { $gpio.pin17 };
+    ($gpio:ident, dig2) => { $gpio.pin18 };
+    ($gpio:ident, dig3) => { $gpio.pin19 };
+    ($gpio:ident, dig4) => { $gpio.pin20 };
+    ($gpio:ident, dig5) => { $gpio.pin21 };
+    ($gpio:ident, dig6) => { $gpio.pin22 };
+    ($gpio:ident, dig7) => { $gpio.pin23 };
+    ($gpio:ident, dig8) => { $gpio.pin0 };
+    ($gpio:ident, dig9) => { $gpio.pin1 };
+    ($gpio:ident, dig10) => { $gpio.pin2 };
+    ($gpio:ident, dig11) => { $gpio.pin3 };
+    ($gpio:ident, dig12) => { $gpio.pin4 };
+    ($gpio:ident, dig13) => { $gpio.pin5 };
+    ($gpio:ident, dig14) => { $gpio.pin8 }; // tested
+    ($gpio:ident, dig15) => { $gpio.pin9 };
+    ($gpio:ident, dig16) => { $gpio.pin10 };
+    ($gpio:ident, dig17) => { $gpio.pin11 };
+    ($gpio:ident, dig18) => { $gpio.pin12 };
+    ($gpio:ident, dig19) => { $gpio.pin13 };
+}
+
+///
+/// Returns single pin for given gpio object mapped accordingly
+/// 
+/// *mappings*
+/// 
+///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
+///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
+///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
+///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
+/// 
+/// *example*
+/// 
+/// `pin!(gpio.spi_mosi) -> gpio.pin3`
+/// 
+#[macro_export]
+macro_rules! pin {
+    ($gpio:ident.$name:ident) => {
+        $crate::pin_name!($gpio, $name)
+    }
+}
+
+///
+/// Returns tuple of pins for given gpio object mapped accordingly
+/// 
+/// *mappings*
+/// 
+///     - none -- Returns () for empty pin if needed in tuple
+///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
+///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
+///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
+///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
+/// 
+/// *example*
+/// 
+/// `pin!(gpio.spi_mosi) -> gpio.pin3`
+/// 
+#[macro_export]
+macro_rules! pins {
+    ( $gpio:ident, ($($name:ident),+) ) => {
+        ($($crate::pin_name!($gpio, $name)),+)
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -4,6 +4,7 @@
 /// Hifive1 PIN mappings (alias -> GPIO.pinX)
 /// 
 #[macro_export]
+#[doc(hidden)]
 macro_rules! pin_name {
     // empty
     ($gpio:ident, none) => { () };

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,9 +1,19 @@
 ///
-/// HiFive1 PIN mappings (alias -> GPIO.pinX)
+/// Returns single pin for given gpio object mapped accordingly
+/// 
+/// *mappings*
+/// 
+///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
+///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
+///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
+///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
+/// 
+/// *example*
+/// 
+/// `pin!(gpio.spi_mosi) -> gpio.pin3`
 /// 
 #[macro_export]
-#[doc(hidden)]
-macro_rules! pin_name {
+macro_rules! pin {
     // empty
     ($gpio:ident, none) => { () };
     // spi
@@ -41,27 +51,6 @@ macro_rules! pin_name {
     ($gpio:ident, dig17) => { $gpio.pin11 };
     ($gpio:ident, dig18) => { $gpio.pin12 };
     ($gpio:ident, dig19) => { $gpio.pin13 };
-}
-
-///
-/// Returns single pin for given gpio object mapped accordingly
-/// 
-/// *mappings*
-/// 
-///     - spi_<what> -- SPI pins where <what> is one of (sck, mosi, miso, ss0, ss2, ss3)
-///     - i2c_<what> -- I2C pins where <what> is one of (sda, scl)
-///     - serial_<what> -- Serial pins where <what> is one of (tx, rx)
-///     - dig# -- Digital/physical pins on the board where # is from range <0..19>
-/// 
-/// *example*
-/// 
-/// `pin!(gpio.spi_mosi) -> gpio.pin3`
-/// 
-#[macro_export]
-macro_rules! pin {
-    ($gpio:ident.$name:ident) => {
-        $crate::pin_name!($gpio, $name)
-    }
 }
 
 ///

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,7 +1,5 @@
-//! GPIO Pin mapping macros crate
-
 ///
-/// Hifive1 PIN mappings (alias -> GPIO.pinX)
+/// HiFive1 PIN mappings (alias -> GPIO.pinX)
 /// 
 #[macro_export]
 #[doc(hidden)]
@@ -79,7 +77,7 @@ macro_rules! pin {
 /// 
 /// *example*
 /// 
-/// `pin!(gpio.spi_mosi) -> gpio.pin3`
+/// `pins!(gpio, (spi_mosi, spi_miso, spi_sck, spi_ss0)) -> (gpio.pin3, gpio.pin4, gpio.pin5, gpio.pin2)`
 /// 
 #[macro_export]
 macro_rules! pins {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -3,15 +3,15 @@
 /// 
 /// # Mappings
 /// 
-///   - `spi_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
-///   - `i2c_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
-///   - `serial_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
+///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
+///   - `uart0_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
 /// # Example
 /// 
 /// ```
-/// let mosi = pin!(gpio, spi_mosi); // gpio.pin3
+/// let mosi = pin!(gpio, spi0_mosi); // gpio.pin3
 /// ```
 /// 
 #[macro_export]
@@ -19,19 +19,19 @@ macro_rules! pin {
     // empty
     ($gpio:ident, none) => { () };
     // spi
-    ($gpio:ident, spi_sck) => { $gpio.pin5 };
-    ($gpio:ident, spi_mosi) => { $gpio.pin3 };
-    ($gpio:ident, spi_miso) => { $gpio.pin4 };
-    ($gpio:ident, spi_ss0) => { $gpio.pin2 };
+    ($gpio:ident, spi0_sck) => { $gpio.pin5 };
+    ($gpio:ident, spi0_mosi) => { $gpio.pin3 };
+    ($gpio:ident, spi0_miso) => { $gpio.pin4 };
+    ($gpio:ident, spi0_ss0) => { $gpio.pin2 };
     // spi_ss1 is not documented
-    ($gpio:ident, spi_ss2) => { $gpio.pin9 };
-    ($gpio:ident, spi_cs3) => { $gpio.pin10 };
+    ($gpio:ident, spi0_ss2) => { $gpio.pin9 };
+    ($gpio:ident, spi0_cs3) => { $gpio.pin10 };
     // i2c
-    ($gpio:ident, i2c_sda) => { $gpio.pin12 };
-    ($gpio:ident, i2c_scl) => { $gpio.pin13 };
+    ($gpio:ident, i2c0_sda) => { $gpio.pin12 };
+    ($gpio:ident, i2c0_scl) => { $gpio.pin13 };
     // serial
-    ($gpio:ident, serial_tx) => { $gpio.pin17 };
-    ($gpio:ident, serial_rx) => { $gpio.pin16 };
+    ($gpio:ident, uart0_tx) => { $gpio.pin17 };
+    ($gpio:ident, uart0_rx) => { $gpio.pin16 };
     // digital/physical
     ($gpio:ident, dig0) => { $gpio.pin16 };
     ($gpio:ident, dig1) => { $gpio.pin17 };
@@ -61,15 +61,15 @@ macro_rules! pin {
 /// # Mappings
 /// 
 ///   - `none` — Returns `()` for empty pin if needed in tuple
-///   - `spi_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
-///   - `i2c_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
-///   - `serial_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
+///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
+///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
+///   - `uart0_<x>` — Serial pins where <x> is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 /// 
 /// # Example
 /// 
 /// ```
-/// let (mosi, miso, sck, cs) = pins!(gpio, (spi_mosi, spi_miso, spi_sck, spi_ss0));
+/// let (mosi, miso, sck, cs) = pins!(gpio, (spi0_mosi, spi0_miso, spi0_sck, spi0_ss0));
 /// // (gpio.pin3, gpio.pin4, gpio.pin5, gpio.pin2)
 /// ```
 /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,5 @@ pub use board::BoardResources;
 
 pub mod stdout;
 pub use stdout::configure as configure_stdout;
+
+pub mod gpio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub use board::BoardResources;
 pub mod stdout;
 pub use stdout::configure as configure_stdout;
 
+#[doc(hidden)]
 pub mod gpio;


### PR DESCRIPTION
Adds the `pin!` and `pins` macros to allow easy GPIO pin selection based on functionality or physical pin location on the board.