### PR TITLE
add SparkFun RED-V board support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ nb = "0.1.2"
 [features]
 board-hifive1 = []
 board-hifive1-revb = ["e310x-hal/g002"]
+board-redv = ["e310x-hal/g002"]
 board-lofive = []
 board-lofive-r1 = ["e310x-hal/g002"]
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 > Board support crate for HiFive1 and LoFive boards
 
+## Supported Boards
+
+`hifive1` - use feature `board-hifive1`
+`hifive1-revb` - use feature `board-hifive1-revb`
+`redv` - use feature `board-redv`
+`lofive` - use feature `board-lofive`
+`lofive-r1` - use feature `board-lofive-r1`
+
 ## [Documentation](https://docs.rs/crate/hifive1)
 
 ## License

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,20 @@
-use std::{env, fs};
 use std::path::PathBuf;
+use std::{env, fs};
 
 fn main() {
     // Put the memory definitions somewhere the linker can find it
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out_dir.display());
 
-    let boards: Vec<_> = env::vars().filter_map(|(key, _value)| {
-        if key.starts_with("CARGO_FEATURE_BOARD") {
-            Some(key[20..].to_ascii_lowercase())  // Strip 'CARGO_FEATURE_BOARD_'
-        } else {
-            None
-        }
-    }).collect();
+    let boards: Vec<_> = env::vars()
+        .filter_map(|(key, _value)| {
+            if key.starts_with("CARGO_FEATURE_BOARD") {
+                Some(key[20..].to_ascii_lowercase()) // Strip 'CARGO_FEATURE_BOARD_'
+            } else {
+                None
+            }
+        })
+        .collect();
 
     if boards.is_empty() {
         panic!("No board features selected");

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ fn main() {
             fs::copy("memory-hifive1.x", out_dir.join("hifive1-memory.x")).unwrap();
             println!("cargo:rerun-if-changed=memory-hifive1.x");
         }
-        "hifive1_revb" => {
+        "hifive1_revb" | "redv" => {
             fs::copy("memory-hifive1-revb.x", out_dir.join("hifive1-memory.x")).unwrap();
             println!("cargo:rerun-if-changed=memory-hifive1-revb.x");
         }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,5 +4,6 @@ set -euxo pipefail
 
 cargo check --target $TARGET --features 'board-hifive1'
 cargo check --target $TARGET --features 'board-hifive1-revb'
+cargo check --target $TARGET --features 'board-redv'
 cargo check --target $TARGET --features 'board-lofive'
 cargo check --target $TARGET --features 'board-lofive-r1'

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -6,7 +6,7 @@ use e310x_hal::{
     time::Hertz,
 };
 
-#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb", feature = "board-redv"))]
 /// Configures clock generation system.
 ///
 /// For HiFive1 and HiFive1 Rev B boards external oscillators are enabled for

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,19 +1,25 @@
 //! Board-specific clock configuration
 
 use e310x_hal::{
-    e310x::{PRCI, AONCLK},
-    clock::{Clocks, PrciExt, AonExt},
+    clock::{AonExt, Clocks, PrciExt},
+    e310x::{AONCLK, PRCI},
     time::Hertz,
 };
 
-#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb", feature = "board-redv"))]
+#[cfg(any(
+    feature = "board-hifive1",
+    feature = "board-hifive1-revb",
+    feature = "board-redv"
+))]
 /// Configures clock generation system.
 ///
 /// For HiFive1 and HiFive1 Rev B boards external oscillators are enabled for
 /// both high-frequency and low-frequency clocks.
 pub fn configure(prci: PRCI, aonclk: AONCLK, target_coreclk: Hertz) -> Clocks {
     let coreclk = prci.constrain();
-    let coreclk = coreclk.use_external(Hertz(16_000_000)).coreclk(target_coreclk);
+    let coreclk = coreclk
+        .use_external(Hertz(16_000_000))
+        .coreclk(target_coreclk);
 
     let aonclk = aonclk.constrain();
     let aonclk = aonclk.use_external(Hertz(32_768));
@@ -28,7 +34,9 @@ pub fn configure(prci: PRCI, aonclk: AONCLK, target_coreclk: Hertz) -> Clocks {
 /// high-frequency clock. For low-frequency clock internal oscillator is used.
 pub fn configure(prci: PRCI, aonclk: AONCLK, target_coreclk: Hertz) -> Clocks {
     let coreclk = prci.constrain();
-    let coreclk = coreclk.use_external(Hertz(16_000_000)).coreclk(target_coreclk);
+    let coreclk = coreclk
+        .use_external(Hertz(16_000_000))
+        .coreclk(target_coreclk);
 
     let aonclk = aonclk.constrain();
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,7 +1,7 @@
 //! On-board SPI Flash
 
-use e310x_hal::e310x::QSPI0;
 use e310x_hal::clock::Clocks;
+use e310x_hal::e310x::QSPI0;
 
 /// Configure SPI Flash interface to maximum supported speed
 #[inline(always)]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,146 +1,278 @@
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 ///
 /// Returns single pin for given gpio object mapped accordingly
-/// 
+///
 /// # Mappings
-/// 
+///
 ///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
 ///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
 ///   - `uart0_<x>` — UART pins where `<x>` is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 ///   - `led_<x>` - Internal LED light pins where `<x>` is one of (`red`, `green`, `blue`)
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// let mosi = pin!(gpio, spi0_mosi); // gpio.pin3
 /// ```
-/// 
+///
 #[macro_export]
 macro_rules! pin {
     // empty
-    ($gpio:ident, none) => { () };
+    ($gpio:ident, none) => {
+        ()
+    };
     // spi
-    ($gpio:ident, spi0_sck) => { $gpio.pin5 };
-    ($gpio:ident, spi0_mosi) => { $gpio.pin3 };
-    ($gpio:ident, spi0_miso) => { $gpio.pin4 };
-    ($gpio:ident, spi0_ss0) => { $gpio.pin2 };
+    ($gpio:ident, spi0_sck) => {
+        $gpio.pin5
+    };
+    ($gpio:ident, spi0_mosi) => {
+        $gpio.pin3
+    };
+    ($gpio:ident, spi0_miso) => {
+        $gpio.pin4
+    };
+    ($gpio:ident, spi0_ss0) => {
+        $gpio.pin2
+    };
     // spi_ss1 is not documented
-    ($gpio:ident, spi0_ss2) => { $gpio.pin9 };
-    ($gpio:ident, spi0_ss3) => { $gpio.pin10 };
+    ($gpio:ident, spi0_ss2) => {
+        $gpio.pin9
+    };
+    ($gpio:ident, spi0_ss3) => {
+        $gpio.pin10
+    };
     // i2c
-    ($gpio:ident, i2c0_sda) => { $gpio.pin12 };
-    ($gpio:ident, i2c0_scl) => { $gpio.pin13 };
+    ($gpio:ident, i2c0_sda) => {
+        $gpio.pin12
+    };
+    ($gpio:ident, i2c0_scl) => {
+        $gpio.pin13
+    };
     // serial
-    ($gpio:ident, uart0_tx) => { $gpio.pin17 };
-    ($gpio:ident, uart0_rx) => { $gpio.pin16 };
+    ($gpio:ident, uart0_tx) => {
+        $gpio.pin17
+    };
+    ($gpio:ident, uart0_rx) => {
+        $gpio.pin16
+    };
     // digital/physical
-    ($gpio:ident, dig0) => { $gpio.pin16 };
-    ($gpio:ident, dig1) => { $gpio.pin17 };
-    ($gpio:ident, dig2) => { $gpio.pin18 };
-    ($gpio:ident, dig3) => { $gpio.pin19 };
-    ($gpio:ident, dig4) => { $gpio.pin20 };
-    ($gpio:ident, dig5) => { $gpio.pin21 };
-    ($gpio:ident, dig6) => { $gpio.pin22 };
-    ($gpio:ident, dig7) => { $gpio.pin23 };
-    ($gpio:ident, dig8) => { $gpio.pin0 };
-    ($gpio:ident, dig9) => { $gpio.pin1 };
-    ($gpio:ident, dig10) => { $gpio.pin2 };
-    ($gpio:ident, dig11) => { $gpio.pin3 };
-    ($gpio:ident, dig12) => { $gpio.pin4 };
-    ($gpio:ident, dig13) => { $gpio.pin5 };
-    ($gpio:ident, dig14) => { $gpio.pin8 }; // tested
-    ($gpio:ident, dig15) => { $gpio.pin9 };
-    ($gpio:ident, dig16) => { $gpio.pin10 };
-    ($gpio:ident, dig17) => { $gpio.pin11 };
-    ($gpio:ident, dig18) => { $gpio.pin12 };
-    ($gpio:ident, dig19) => { $gpio.pin13 };
+    ($gpio:ident, dig0) => {
+        $gpio.pin16
+    };
+    ($gpio:ident, dig1) => {
+        $gpio.pin17
+    };
+    ($gpio:ident, dig2) => {
+        $gpio.pin18
+    };
+    ($gpio:ident, dig3) => {
+        $gpio.pin19
+    };
+    ($gpio:ident, dig4) => {
+        $gpio.pin20
+    };
+    ($gpio:ident, dig5) => {
+        $gpio.pin21
+    };
+    ($gpio:ident, dig6) => {
+        $gpio.pin22
+    };
+    ($gpio:ident, dig7) => {
+        $gpio.pin23
+    };
+    ($gpio:ident, dig8) => {
+        $gpio.pin0
+    };
+    ($gpio:ident, dig9) => {
+        $gpio.pin1
+    };
+    ($gpio:ident, dig10) => {
+        $gpio.pin2
+    };
+    ($gpio:ident, dig11) => {
+        $gpio.pin3
+    };
+    ($gpio:ident, dig12) => {
+        $gpio.pin4
+    };
+    ($gpio:ident, dig13) => {
+        $gpio.pin5
+    };
+    ($gpio:ident, dig14) => {
+        $gpio.pin8
+    }; // tested
+    ($gpio:ident, dig15) => {
+        $gpio.pin9
+    };
+    ($gpio:ident, dig16) => {
+        $gpio.pin10
+    };
+    ($gpio:ident, dig17) => {
+        $gpio.pin11
+    };
+    ($gpio:ident, dig18) => {
+        $gpio.pin12
+    };
+    ($gpio:ident, dig19) => {
+        $gpio.pin13
+    };
     // onboard LEDs
-    ($gpio:ident, led_red) => { $gpio.pin22 };
-    ($gpio:ident, led_green) => { $gpio.pin19 };
-    ($gpio:ident, led_blue) => { $gpio.pin21 };
+    ($gpio:ident, led_red) => {
+        $gpio.pin22
+    };
+    ($gpio:ident, led_green) => {
+        $gpio.pin19
+    };
+    ($gpio:ident, led_blue) => {
+        $gpio.pin21
+    };
 }
 
 #[cfg(feature = "board-redv")]
 ///
 /// Returns single pin for given gpio object mapped accordingly
-/// 
+///
 /// # Mappings
-/// 
+///
 ///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
 ///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
 ///   - `uart0_<x>` — UART pins where `<x>` is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 ///   - `led_<x>` - Internal LED light pins where `<x>` is one of (`red`, `green`, `blue`)
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// let mosi = pin!(gpio, spi0_mosi); // gpio.pin3
 /// ```
-/// 
+///
 #[macro_export]
 macro_rules! pin {
     // empty
-    ($gpio:ident, none) => { () };
+    ($gpio:ident, none) => {
+        ()
+    };
     // spi
-    ($gpio:ident, spi0_sck) => { $gpio.pin5 };
-    ($gpio:ident, spi0_mosi) => { $gpio.pin3 };
-    ($gpio:ident, spi0_miso) => { $gpio.pin4 };
-    ($gpio:ident, spi0_ss0) => { $gpio.pin2 };
+    ($gpio:ident, spi0_sck) => {
+        $gpio.pin5
+    };
+    ($gpio:ident, spi0_mosi) => {
+        $gpio.pin3
+    };
+    ($gpio:ident, spi0_miso) => {
+        $gpio.pin4
+    };
+    ($gpio:ident, spi0_ss0) => {
+        $gpio.pin2
+    };
     // spi_ss1 is not documented
-    ($gpio:ident, spi0_ss2) => { $gpio.pin9 };
-    ($gpio:ident, spi0_ss3) => { $gpio.pin10 };
+    ($gpio:ident, spi0_ss2) => {
+        $gpio.pin9
+    };
+    ($gpio:ident, spi0_ss3) => {
+        $gpio.pin10
+    };
     // i2c
-    ($gpio:ident, i2c0_sda) => { $gpio.pin12 };
-    ($gpio:ident, i2c0_scl) => { $gpio.pin13 };
+    ($gpio:ident, i2c0_sda) => {
+        $gpio.pin12
+    };
+    ($gpio:ident, i2c0_scl) => {
+        $gpio.pin13
+    };
     // serial
-    ($gpio:ident, uart0_tx) => { $gpio.pin17 };
-    ($gpio:ident, uart0_rx) => { $gpio.pin16 };
+    ($gpio:ident, uart0_tx) => {
+        $gpio.pin17
+    };
+    ($gpio:ident, uart0_rx) => {
+        $gpio.pin16
+    };
     // digital/physical
-    ($gpio:ident, dig0) => { $gpio.pin16 };
-    ($gpio:ident, dig1) => { $gpio.pin17 };
-    ($gpio:ident, dig2) => { $gpio.pin18 };
-    ($gpio:ident, dig3) => { $gpio.pin19 };
-    ($gpio:ident, dig4) => { $gpio.pin20 };
-    ($gpio:ident, dig5) => { $gpio.pin21 };
-    ($gpio:ident, dig6) => { $gpio.pin22 };
-    ($gpio:ident, dig7) => { $gpio.pin23 };
-    ($gpio:ident, dig8) => { $gpio.pin0 };
-    ($gpio:ident, dig9) => { $gpio.pin1 };
-    ($gpio:ident, dig10) => { $gpio.pin2 };
-    ($gpio:ident, dig11) => { $gpio.pin3 };
-    ($gpio:ident, dig12) => { $gpio.pin4 };
-    ($gpio:ident, dig13) => { $gpio.pin5 };
-    ($gpio:ident, dig14) => { $gpio.pin8 }; // tested
-    ($gpio:ident, dig15) => { $gpio.pin9 };
-    ($gpio:ident, dig16) => { $gpio.pin10 };
-    ($gpio:ident, dig17) => { $gpio.pin11 };
-    ($gpio:ident, dig18) => { $gpio.pin12 };
-    ($gpio:ident, dig19) => { $gpio.pin13 };
+    ($gpio:ident, dig0) => {
+        $gpio.pin16
+    };
+    ($gpio:ident, dig1) => {
+        $gpio.pin17
+    };
+    ($gpio:ident, dig2) => {
+        $gpio.pin18
+    };
+    ($gpio:ident, dig3) => {
+        $gpio.pin19
+    };
+    ($gpio:ident, dig4) => {
+        $gpio.pin20
+    };
+    ($gpio:ident, dig5) => {
+        $gpio.pin21
+    };
+    ($gpio:ident, dig6) => {
+        $gpio.pin22
+    };
+    ($gpio:ident, dig7) => {
+        $gpio.pin23
+    };
+    ($gpio:ident, dig8) => {
+        $gpio.pin0
+    };
+    ($gpio:ident, dig9) => {
+        $gpio.pin1
+    };
+    ($gpio:ident, dig10) => {
+        $gpio.pin2
+    };
+    ($gpio:ident, dig11) => {
+        $gpio.pin3
+    };
+    ($gpio:ident, dig12) => {
+        $gpio.pin4
+    };
+    ($gpio:ident, dig13) => {
+        $gpio.pin5
+    };
+    ($gpio:ident, dig14) => {
+        $gpio.pin8
+    }; // tested
+    ($gpio:ident, dig15) => {
+        $gpio.pin9
+    };
+    ($gpio:ident, dig16) => {
+        $gpio.pin10
+    };
+    ($gpio:ident, dig17) => {
+        $gpio.pin11
+    };
+    ($gpio:ident, dig18) => {
+        $gpio.pin12
+    };
+    ($gpio:ident, dig19) => {
+        $gpio.pin13
+    };
     // onboard LEDs
-    ($gpio:ident, led_blue) => { $gpio.pin4 };
+    ($gpio:ident, led_blue) => {
+        $gpio.pin5
+    };
 }
 
 ///
 /// Returns tuple of pins for given gpio object mapped accordingly
-/// 
+///
 /// # Mappings
-/// 
+///
 ///   - `none` — Returns `()` for empty pin if needed in tuple
 ///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
 ///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
 ///   - `uart0_<x>` — UART pins where `<x>` is one of (`tx`, `rx`)
 ///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
 ///   - `led_<x>` - Internal LED light pins `<x>` is one of (`red`, `green`, `blue`)
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// let (mosi, miso, sck, cs) = pins!(gpio, (spi0_mosi, spi0_miso, spi0_sck, spi0_ss0));
 /// // (gpio.pin3, gpio.pin4, gpio.pin5, gpio.pin2)
 /// ```
-/// 
+///
 #[macro_export]
 macro_rules! pins {
     ( $gpio:ident, ($($name:ident),+) ) => {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 ///
 /// Returns single pin for given gpio object mapped accordingly
 /// 
@@ -58,7 +59,69 @@ macro_rules! pin {
     ($gpio:ident, led_red) => { $gpio.pin22 };
     ($gpio:ident, led_green) => { $gpio.pin19 };
     ($gpio:ident, led_blue) => { $gpio.pin21 };
+    // #[cfg(feature = "redv")]
+    // ($gpio:ident, led_blue) => { $gpio.pin4 };
+}
 
+#[cfg(feature = "board-redv")]
+///
+/// Returns single pin for given gpio object mapped accordingly
+/// 
+/// # Mappings
+/// 
+///   - `spi0_<x>` — SPI pins where `<x>` is one of (`sck`, `mosi`, `miso`, `ss0`, `ss2`, `ss3`)
+///   - `i2c0_<x>` — I2C pins where `<x>` is one of (`sda`, `scl`)
+///   - `uart0_<x>` — UART pins where `<x>` is one of (`tx`, `rx`)
+///   - `dig#` — Digital/physical pins on the board where `#` is from range 0..19
+///   - `led_<x>` - Internal LED light pins where `<x>` is one of (`red`, `green`, `blue`)
+/// 
+/// # Example
+/// 
+/// ```
+/// let mosi = pin!(gpio, spi0_mosi); // gpio.pin3
+/// ```
+/// 
+#[macro_export]
+macro_rules! pin {
+    // empty
+    ($gpio:ident, none) => { () };
+    // spi
+    ($gpio:ident, spi0_sck) => { $gpio.pin5 };
+    ($gpio:ident, spi0_mosi) => { $gpio.pin3 };
+    ($gpio:ident, spi0_miso) => { $gpio.pin4 };
+    ($gpio:ident, spi0_ss0) => { $gpio.pin2 };
+    // spi_ss1 is not documented
+    ($gpio:ident, spi0_ss2) => { $gpio.pin9 };
+    ($gpio:ident, spi0_ss3) => { $gpio.pin10 };
+    // i2c
+    ($gpio:ident, i2c0_sda) => { $gpio.pin12 };
+    ($gpio:ident, i2c0_scl) => { $gpio.pin13 };
+    // serial
+    ($gpio:ident, uart0_tx) => { $gpio.pin17 };
+    ($gpio:ident, uart0_rx) => { $gpio.pin16 };
+    // digital/physical
+    ($gpio:ident, dig0) => { $gpio.pin16 };
+    ($gpio:ident, dig1) => { $gpio.pin17 };
+    ($gpio:ident, dig2) => { $gpio.pin18 };
+    ($gpio:ident, dig3) => { $gpio.pin19 };
+    ($gpio:ident, dig4) => { $gpio.pin20 };
+    ($gpio:ident, dig5) => { $gpio.pin21 };
+    ($gpio:ident, dig6) => { $gpio.pin22 };
+    ($gpio:ident, dig7) => { $gpio.pin23 };
+    ($gpio:ident, dig8) => { $gpio.pin0 };
+    ($gpio:ident, dig9) => { $gpio.pin1 };
+    ($gpio:ident, dig10) => { $gpio.pin2 };
+    ($gpio:ident, dig11) => { $gpio.pin3 };
+    ($gpio:ident, dig12) => { $gpio.pin4 };
+    ($gpio:ident, dig13) => { $gpio.pin5 };
+    ($gpio:ident, dig14) => { $gpio.pin8 }; // tested
+    ($gpio:ident, dig15) => { $gpio.pin9 };
+    ($gpio:ident, dig16) => { $gpio.pin10 };
+    ($gpio:ident, dig17) => { $gpio.pin11 };
+    ($gpio:ident, dig18) => { $gpio.pin12 };
+    ($gpio:ident, dig19) => { $gpio.pin13 };
+    // onboard LEDs
+    ($gpio:ident, led_blue) => { $gpio.pin4 };
 }
 
 ///

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -59,8 +59,6 @@ macro_rules! pin {
     ($gpio:ident, led_red) => { $gpio.pin22 };
     ($gpio:ident, led_green) => { $gpio.pin19 };
     ($gpio:ident, led_blue) => { $gpio.pin21 };
-    // #[cfg(feature = "redv")]
-    // ($gpio:ident, led_blue) => { $gpio.pin4 };
 }
 
 #[cfg(feature = "board-redv")]

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,21 +1,37 @@
 //! On-board user LEDs
 //!
+//! Hifive1 (+ revB)
 //! - Red = Pin 22
 //! - Green = Pin 19
 //! - Blue = Pin 21
+//!
+//! RedV
+//! - Blue = Pin 4
+
 use embedded_hal::digital::v2::OutputPin;
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 use e310x_hal::gpio::gpio0::{Pin19, Pin21, Pin22};
+#[cfg(feature = "board-redv")]
+use e310x_hal::gpio::gpio0::{Pin4};
 use e310x_hal::gpio::{Output, Regular, Invert};
 
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Red LED
 pub type RED = Pin22<Output<Regular<Invert>>>;
 
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Green LED
 pub type GREEN = Pin19<Output<Regular<Invert>>>;
 
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Blue LED
 pub type BLUE = Pin21<Output<Regular<Invert>>>;
 
+#[cfg(feature = "board-redv")]
+/// Blue LED
+pub type BLUE = Pin4<Output<Regular<Invert>>>;
+
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Returns RED, GREEN and BLUE LEDs.
 pub fn rgb<X, Y, Z>(
     red: Pin22<X>, green: Pin19<Y>, blue: Pin21<Z>
@@ -36,6 +52,7 @@ pub trait Led {
     fn on(&mut self);
 }
 
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 impl Led for RED {
     fn off(&mut self) {
         self.set_low().unwrap();
@@ -46,6 +63,7 @@ impl Led for RED {
     }
 }
 
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 impl Led for GREEN {
     fn off(&mut self) {
         self.set_low().unwrap();

--- a/src/led.rs
+++ b/src/led.rs
@@ -6,14 +6,14 @@
 //! - Blue = Pin 21
 //!
 //! RedV
-//! - Blue = Pin 4
+//! - Blue = Pin 5
 
-use embedded_hal::digital::v2::OutputPin;
+#[cfg(feature = "board-redv")]
+use e310x_hal::gpio::gpio0::Pin5;
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 use e310x_hal::gpio::gpio0::{Pin19, Pin21, Pin22};
-#[cfg(feature = "board-redv")]
-use e310x_hal::gpio::gpio0::{Pin4};
-use e310x_hal::gpio::{Output, Regular, Invert};
+use e310x_hal::gpio::{Invert, Output, Regular};
+use embedded_hal::digital::v2::OutputPin;
 
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Red LED
@@ -29,14 +29,11 @@ pub type BLUE = Pin21<Output<Regular<Invert>>>;
 
 #[cfg(feature = "board-redv")]
 /// Blue LED
-pub type BLUE = Pin4<Output<Regular<Invert>>>;
+pub type BLUE = Pin5<Output<Regular<Invert>>>;
 
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Returns RED, GREEN and BLUE LEDs.
-pub fn rgb<X, Y, Z>(
-    red: Pin22<X>, green: Pin19<Y>, blue: Pin21<Z>
-) -> (RED, GREEN, BLUE)
-{
+pub fn rgb<X, Y, Z>(red: Pin22<X>, green: Pin19<Y>, blue: Pin21<Z>) -> (RED, GREEN, BLUE) {
     let red: RED = red.into_inverted_output();
     let green: GREEN = green.into_inverted_output();
     let blue: BLUE = blue.into_inverted_output();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,16 @@ pub use clock::configure as configure_clocks;
 
 pub mod flash;
 
-#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb", feature = "board-redv"))]
+#[cfg(any(
+    feature = "board-hifive1",
+    feature = "board-hifive1-revb",
+    feature = "board-redv"
+))]
 pub mod led;
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
-pub use led::{RED, GREEN, BLUE, rgb, Led};
+pub use led::{rgb, Led, BLUE, GREEN, RED};
 #[cfg(feature = "board-redv")]
-pub use led::{BLUE, Led};
+pub use led::{Led, BLUE};
 
 pub mod stdout;
 pub use stdout::configure as configure_stdout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,12 @@ pub use clock::configure as configure_clocks;
 
 pub mod flash;
 
-#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
+#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb", feature = "board-redv"))]
 pub mod led;
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 pub use led::{RED, GREEN, BLUE, rgb, Led};
+#[cfg(feature = "board-redv")]
+pub use led::{BLUE, Led};
 
 pub mod stdout;
 pub use stdout::configure as configure_stdout;


### PR DESCRIPTION
Adds `board-redv` support with updated LED/GPIO mappings.