### PR TITLE
Substitute multiple LED impl calls with a generic macro & add the toggle() method

### DIFF
--- a/src/led.rs
+++ b/src/led.rs
@@ -13,7 +13,7 @@ use e310x_hal::gpio::gpio0::Pin5;
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 use e310x_hal::gpio::gpio0::{Pin19, Pin21, Pin22};
 use e310x_hal::gpio::{Invert, Output, Regular};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
 
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
 /// Red LED
@@ -47,36 +47,34 @@ pub trait Led {
 
     /// Turns the LED on
     fn on(&mut self);
+
+    /// Toggles the LED state
+    fn toggle(&mut self);
 }
 
+/// Macro to implement the Led trait for each of the board LEDs
+macro_rules! led_impl {
+    ($($LEDTYPE:ident),+) => {
+        $(
+            impl Led for $LEDTYPE {
+            fn off(&mut self) {
+                self.set_low().unwrap();
+            }
+
+            fn on(&mut self) {
+                self.set_high().unwrap();
+            }
+
+            fn toggle(&mut self) {
+                ToggleableOutputPin::toggle(self).unwrap();
+            }
+        }
+        )+
+    }
+}
+
+/// Call the macro for each LED
 #[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
-impl Led for RED {
-    fn off(&mut self) {
-        self.set_low().unwrap();
-    }
+led_impl!(RED, GREEN);
 
-    fn on(&mut self) {
-        self.set_high().unwrap();
-    }
-}
-
-#[cfg(any(feature = "board-hifive1", feature = "board-hifive1-revb"))]
-impl Led for GREEN {
-    fn off(&mut self) {
-        self.set_low().unwrap();
-    }
-
-    fn on(&mut self) {
-        self.set_high().unwrap();
-    }
-}
-
-impl Led for BLUE {
-    fn off(&mut self) {
-        self.set_low().unwrap();
-    }
-
-    fn on(&mut self) {
-        self.set_high().unwrap();
-    }
-}
+led_impl!(BLUE);

--- a/src/led.rs
+++ b/src/led.rs
@@ -57,18 +57,18 @@ macro_rules! led_impl {
     ($($LEDTYPE:ident),+) => {
         $(
             impl Led for $LEDTYPE {
-            fn off(&mut self) {
-                self.set_low().unwrap();
-            }
+                fn off(&mut self) {
+                    self.set_low().unwrap();
+                }
 
-            fn on(&mut self) {
-                self.set_high().unwrap();
-            }
+                fn on(&mut self) {
+                    self.set_high().unwrap();
+                }
 
-            fn toggle(&mut self) {
-                ToggleableOutputPin::toggle(self).unwrap();
+                fn toggle(&mut self) {
+                    ToggleableOutputPin::toggle(self).unwrap();
+                }
             }
-        }
         )+
     }
 }

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -19,8 +19,8 @@ struct SerialWrapper(Tx<UART0>);
 impl core::fmt::Write for SerialWrapper {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for byte in s.as_bytes() {
-            if *byte == '\n' as u8 {
-                let res = block!(self.0.write('\r' as u8));
+            if *byte == b'\n' {
+                let res = block!(self.0.write(b'\r'));
 
                 if res.is_err() {
                     return Err(::core::fmt::Error);
@@ -53,7 +53,7 @@ pub fn configure<X, Y>(
     interrupt::free(|_| unsafe {
         STDOUT.replace(SerialWrapper(tx));
     });
-    return rx;
+    rx
 }
 
 /// Writes string to stdout


### PR DESCRIPTION
This pull request simplifies the code for the LED impl calls substituting them with a single macro call (following the original features) and adds an additional toggle() method from the ToggleableOutputPin trait.