### PR TITLE
release v0.12.0 with updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.12.0] - 2023-03-28
+- Update e310x-hal to v0.11 with new svd2rust generated code
+
 ## [v0.11.0] - 2023-03-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifive1"
-version = "0.11.0"
+version = "0.12.0"
 repository = "https://github.com/riscv-rust/hifive1"
 authors = ["David Craven <david@craven.ch>"]
 categories = ["embedded", "hardware-support", "no-std"]
@@ -11,7 +11,7 @@ edition = "2018"
 rust-version = "1.59"
 
 [dependencies]
-e310x-hal = "0.9.3"
+e310x-hal = "0.11.0"
 embedded-hal = "0.2.7"
 riscv = "0.10.1"
 nb = "1.0.0"

--- a/memory-hifive1-revb.x
+++ b/memory-hifive1-revb.x
@@ -1,4 +1,4 @@
-INCLUDE memory-fe310.x
+INCLUDE device.x
 MEMORY
 {
     FLASH : ORIGIN = 0x20000000, LENGTH = 4M

--- a/memory-hifive1.x
+++ b/memory-hifive1.x
@@ -1,4 +1,4 @@
-INCLUDE memory-fe310.x
+INCLUDE device.x
 MEMORY
 {
     FLASH : ORIGIN = 0x20000000, LENGTH = 16M

--- a/memory-lofive-r1.x
+++ b/memory-lofive-r1.x
@@ -1,4 +1,4 @@
-INCLUDE memory-fe310.x
+INCLUDE device.x
 MEMORY
 {
     FLASH : ORIGIN = 0x20000000, LENGTH = 16M


### PR DESCRIPTION
Updates e310x-hal to v0.11

Depends on [#52](https://github.com/riscv-rust/e310x-hal/pull/52) and [#29](https://github.com/riscv-rust/e310x/pull/29)